### PR TITLE
feat:플레이어 상태 변경하여 움직이는 로직 추가

### DIFF
--- a/Assets/2.Scenes/SC.unity
+++ b/Assets/2.Scenes/SC.unity
@@ -445,7 +445,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!1 &1378107978
 GameObject:
   m_ObjectHideFlags: 0
@@ -461,6 +461,8 @@ GameObject:
   - component: {fileID: 1378107983}
   - component: {fileID: 1378107985}
   - component: {fileID: 1378107984}
+  - component: {fileID: 1378107987}
+  - component: {fileID: 1378107986}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -614,6 +616,79 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47ec40d0f0fd5914fa1771d4bc9d54a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!61 &1378107986
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378107978}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.1, y: 2.9}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 2.1, y: 2.9}
+  m_EdgeRadius: 0
+--- !u!50 &1378107987
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378107978}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/3.Script/Player/Player.cs
+++ b/Assets/3.Script/Player/Player.cs
@@ -38,7 +38,13 @@ public class Player : MonoBehaviour
     {
         while (true)
         {
-            state.CheckTransition();
+            IState getState = state.CheckTransition();
+            if(getState != null)  //state°¡ ¹Ù²î¸é true  ¾È¹Ù²î¸é false
+            {
+                state.ExitState();
+                state = getState;
+                state.EnterState();
+            }
             state.OnUpdate();
             yield return null;
         }

--- a/Assets/3.Script/Player/PlayerAttack.cs
+++ b/Assets/3.Script/Player/PlayerAttack.cs
@@ -16,6 +16,7 @@ public class PlayerAttack : MonoBehaviour,IState
         damage = stat.Damage;
         attackSpeed = stat.AttackSpeed;
         attackRange = stat.AttackRange;
+        moveState = GetComponent<PlayerMove>();
     }
 
     private void Attack()
@@ -51,7 +52,7 @@ public class PlayerAttack : MonoBehaviour,IState
         Collider2D[] cols = Physics2D.OverlapBoxAll(transform.position + new Vector3(attackRange/2, 0), new Vector3(attackRange, attackRange), 0);
         foreach (Collider2D col in cols)
         {
-            if(col.TryGetComponent<EnemyStat>(out var enemy))
+            if (col.TryGetComponent<EnemyStat>(out var enemy))
                 return enemy.GetComponent<IGetDamage>();
         }
         return null;
@@ -64,6 +65,9 @@ public class PlayerAttack : MonoBehaviour,IState
 
     public IState CheckTransition()
     {
-       return moveState;
+        if (GetTarget() == null)
+            return moveState;
+        else
+            return null;
     }
 }

--- a/Assets/3.Script/Player/PlayerMove.cs
+++ b/Assets/3.Script/Player/PlayerMove.cs
@@ -8,6 +8,7 @@ public class PlayerMove : MonoBehaviour,IState
     public void Init()
     {
        rigid = GetComponent<Rigidbody2D>();
+        attackState = GetComponent<PlayerAttack>();
     }
 
     public void EnterState()
@@ -27,12 +28,13 @@ public class PlayerMove : MonoBehaviour,IState
 
     public IState CheckTransition()
     {
-        Collider2D col = Physics2D.OverlapBox(transform.position + new Vector3(attackRange / 2, 0), new Vector3(attackRange, attackRange), 0);
-
-        if (col != null)
-            return attackState;
-        else
-            return null;
+        Collider2D[] cols = Physics2D.OverlapBoxAll(transform.position + new Vector3(attackRange / 2, 0), new Vector3(attackRange, attackRange), 0);
+        foreach (Collider2D col in cols)
+        {
+            if (col.TryGetComponent<EnemyStat>(out _))
+                return attackState;
+        }
+        return null;
     }
 
     public void OnDrawGizmos()


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fea/playerMove -> dev

### 작업사항 :memo:
플레이어가 적이 공격 범위안에 없으면 이동하는 로직을 추가했습니다

### 테스트 방법
`적 오브젝트를 공격 범위 밖으로 빼거나 삭제시켜서 플레이어가 앞으로 움직이는것을 확인합니다


### 테스트 결과
`공격 범위 밖으로 나가거나 삭제시키면 플레이어가 앞으로 이동합니다
